### PR TITLE
Fix for quadratic Beziers

### DIFF
--- a/matplotlib2tikz.py
+++ b/matplotlib2tikz.py
@@ -1390,6 +1390,9 @@ def _draw_legend(data, obj):
     return data
 
 
+def _escape_text(text):
+    return text.replace('_', '\\_')
+
 def _draw_text(data, obj):
     '''Paints text on the graph.
     '''
@@ -1447,7 +1450,7 @@ def _draw_text(data, obj):
     #                   -------1--------2---3--4--
     proto = '\\node at (axis cs:%.15g,%.15g)[\n  %s\n]{%s %s};\n'
     pos = obj.get_position()
-    text = obj.get_text()
+    text = _escape_text(obj.get_text())
     size = obj.get_size()
     bbox = obj.get_bbox_patch()
     converter = mpl.colors.ColorConverter()

--- a/matplotlib2tikz.py
+++ b/matplotlib2tikz.py
@@ -651,7 +651,6 @@ def _linear_interpolation(x, X, Y):
     '''
     return (Y[1] * (x - X[0]) + Y[0] * (X[1] - x)) / (X[1] - X[0])
 
-
 def _transform_to_data_coordinates(obj, xdata, ydata):
     '''Transform to data coordinates
     The coordinates might not be in data coordinates, but could be partly in
@@ -1173,6 +1172,7 @@ def _draw_path(obj, data, path,
     nodes = []
     prev = None
     for vert, code in path.iter_segments():
+        savedvert = vert
         vert = np.asarray(_transform_to_data_coordinates(obj,
                                                          [vert[0]],
                                                          [vert[1]]
@@ -1203,14 +1203,24 @@ def _draw_path(obj, data, path,
             if prev is None:
                 raise RuntimeError('Cannot draw quadratic Bezier curves '
                                    'as the beginning of of a path.')
-            Q1 = 1. / 3. * prev + 2. / 3. * vert[0:2]
-            Q2 = 2. / 3. * vert[0:2] + 1. / 3. * vert[2:4]
-            Q3 = vert[2:4]
+            # formatting via autopep8
+            v1, v2 = (np.array(v)[:, np.newaxis]
+                      for v in zip(*np.asarray(
+                                   _transform_to_data_coordinates(obj,
+                                                                  savedvert[
+                                                                      0::2],
+                                                                  savedvert[
+                                                                      1::2]
+                                                                  ))))
+            Q1 = 1. / 3. * prev + 2. / 3. * v1
+            Q2 = 2. / 3. * v1 + 1. / 3. * v2
+            Q3 = v2
             nodes.append(('.. controls (axis cs:%.15g,%.15g) '
                           + 'and (axis cs:%.15g,%.15g) '
                           + '.. (axis cs:%.15g,%.15g)')
-                         % tuple(Q1 + Q2 + Q3)
+                         % tuple(tuple(Q1) + tuple(Q2) + tuple(Q3))
                          )
+            vert = v2
         elif code == mpl.path.Path.CURVE4:
             # Cubic Bezier curves.
             nodes.append(('.. controls (axis cs:%.15g,%.15g) '


### PR DESCRIPTION
Hi,
I've been trying to draw boxes with rounded corners a la http://matplotlib.org/examples/pylab_examples/fancybox_demo.html. The FancyBboxPatch seems to cause an error in _draw_path because the vertices are not being correctly transformed. This patch is a fix for the `Path.CURVE3` case. Not sure if this is a good long-term solution (I don't know what other cases are affected), but it does allow me to use `FancyBboxPatch`. Please let me know if there are some tests I should run on this or anything else that you would want in order to accept it.