### PR TITLE
Fix text alignment (e.g. in annotations)

### DIFF
--- a/matplotlib2tikz/text.py
+++ b/matplotlib2tikz/text.py
@@ -162,7 +162,7 @@ def draw_text(data, obj):
 
     if '\n' in text:
         # http://tex.stackexchange.com/a/124114/13262
-        properties.append('align=left')
+        properties.append('align=%s' % ha)
         # Manipulating the text here is actually against mpl2tikz's policy not
         # to do that. On the other hand, newlines should translate into
         # newlines.


### PR DESCRIPTION
The text alignment setting for text with linebreaks (e.g. in annotations) was not set correctly.

An simple example would be:
ax.annotate('line1\n line2', xy=(1, 2), horizontalalignment='right')

The default horizontal alignment is 'left'.
