### PR TITLE
text.py - Make sure % and & are translated correctly

### DIFF
--- a/matplotlib2tikz/text.py
+++ b/matplotlib2tikz/text.py
@@ -169,6 +169,10 @@ def draw_text(data, obj):
         # We might want to remove this here in the future.
         text = text.replace('\n ', '\\\\')
 
+    # Make sure % and & are translated correctly
+    text = text.replace('&', '\&')
+    text = text.replace('%', '\%')
+
     content.append(
             '\\node at %s[\n  %s\n]{%s %s};\n' %
             (tikz_pos, ',\n  '.join(properties), ' '.join(style), text)


### PR DESCRIPTION
In (La)TeX "%" and "&" have a special meaning and need to be escaped in normal text.

In fact, the following ten characters have special meanings in (La)TeX:
& % $ # _ { } ~ ^ \
I don't think it's wise to escape all of them in the text, since it would permit to use (La)TeX constructs (e.g. subscripts) from within python.
But comments (i.e. "%") and column separators (i.e. "&") should not be used in annotations or labels and hence I would deem it save to escape them.