### PR TITLE
Fix line style of marker edges 

### DIFF
--- a/matplotlib2tikz/line2d.py
+++ b/matplotlib2tikz/line2d.py
@@ -46,7 +46,7 @@ def draw_line2d(data, obj):
                 pgf_size = 1
             addplot_options.append('mark size=%d' % pgf_size)
 
-        mark_options = []
+        mark_options = ['solid']
         if extra_mark_options:
             mark_options.append(extra_mark_options)
         if marker_face_color is not None:
@@ -65,9 +65,7 @@ def draw_line2d(data, obj):
                     )
             if draw_xcolor != line_xcolor:
                 mark_options.append('draw=' + draw_xcolor)
-        if mark_options:
-            addplot_options.append('mark options={%s}' % ','.join(mark_options)
-                                   )
+        addplot_options.append('mark options={%s}' % ','.join(mark_options))
 
     if marker and not show_line:
         addplot_options.append('only marks')

--- a/test/testfunctions/legends2.py
+++ b/test/testfunctions/legends2.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 desc = 'Another legend plot'
-phash = '5f31c1ca35bc2c72'
+phash = '5f31c1ca34bcac72'
 
 def plot():
     from matplotlib import pyplot as pp

--- a/test/testfunctions/marker.py
+++ b/test/testfunctions/marker.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+#
+desc = 'Simple $\sin$ and $\cos$ plots with markers'
+phash = 'ef2c9732217456ac'
+
+
+def plot():
+    from matplotlib import pyplot as plt
+    import numpy as np
+
+    fig, ax = plt.subplots()
+    with plt.style.context(('ggplot')):
+        t = np.linspace(0, 2*np.pi, 101)
+        s = np.sin(t)
+        c = np.cos(t)
+        ax.plot(t, s, 'ko-', mec='r', markevery=20)
+        ax.plot(t, c, 'ks--', mec='r', markevery=20)
+        ax.set_xlim(t[0], t[-1])
+        ax.set_xlabel('t')
+        ax.set_ylabel('y')
+        ax.set_title('Simple plot')
+        ax.grid(True)
+    return fig


### PR DESCRIPTION
Set the line style of marker edges always to 'solid'. Otherwise the line style of the actual lines os used, which in case of e.g. dotted lines leads to a wrong output.

This is also consistent with the way matplotlib set the line style of the marker edges.

A test is included.
