### PR TITLE
Add quadmesh support

### DIFF
--- a/matplotlib2tikz/quadmesh.py
+++ b/matplotlib2tikz/quadmesh.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 #
 import os
-import matplotlib as mpl
 
 from PIL import Image
 
@@ -23,10 +22,7 @@ def draw_quadmesh(data, obj):
     data['img number'] = data['img number'] + 1
 
     # Get the dpi for rendering and store the original dpi of the figure
-    if data['dpi']:
-        dpi = data['dpi']
-    else:
-        dpi = mpl.rcParams['savefig.dpi']
+    dpi = data['dpi']
     fig_dpi = obj.figure.get_dpi()
     obj.figure.set_dpi(dpi)
 

--- a/matplotlib2tikz/quadmesh.py
+++ b/matplotlib2tikz/quadmesh.py
@@ -43,7 +43,8 @@ def draw_quadmesh(data, obj):
     # Crop the image to the actual content (removing the the regions otherwise
     # used for axes, etc.)
     # 'image.crop' expects the crop box to specify the left, upper, right, and
-    # lower pixel. 'cbox.extents' gives the left, lower, right, and upper pixel.
+    # lower pixel. 'cbox.extents' gives the left, lower, right, and upper
+    # pixel.
     box = (int(round(cbox.extents[0])),
            0,
            int(round(cbox.extents[2])),

--- a/matplotlib2tikz/quadmesh.py
+++ b/matplotlib2tikz/quadmesh.py
@@ -2,7 +2,8 @@
 #
 import os
 import matplotlib as mpl
-from matplotlib.backends import backend_agg
+from matplotlib.backends.backend_agg import RendererAgg
+
 from PIL import Image
 
 
@@ -34,7 +35,7 @@ def draw_quadmesh(data, obj):
     cbox = obj.get_clip_box()
     width = int(round(cbox.extents[2]))
     height = int(round(cbox.extents[3]))
-    ren = backend_agg.RendererAgg(width, height, dpi)
+    ren = RendererAgg(width, height, dpi)
     obj.draw(ren)
 
     # Generate a image from the render buffer

--- a/matplotlib2tikz/quadmesh.py
+++ b/matplotlib2tikz/quadmesh.py
@@ -2,7 +2,6 @@
 #
 import os
 import matplotlib as mpl
-from matplotlib.backends.backend_agg import RendererAgg
 
 from PIL import Image
 
@@ -32,6 +31,7 @@ def draw_quadmesh(data, obj):
     obj.figure.set_dpi(dpi)
 
     # Render the object and save as png file
+    from matplotlib.backends.backend_agg import RendererAgg
     cbox = obj.get_clip_box()
     width = int(round(cbox.extents[2]))
     height = int(round(cbox.extents[3]))

--- a/matplotlib2tikz/quadmesh.py
+++ b/matplotlib2tikz/quadmesh.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+#
+import os
+import matplotlib as mpl
+from matplotlib.backends import backend_agg
+from PIL import Image
+
+
+def draw_quadmesh(data, obj):
+    '''Returns the PGFPlots code for an graphics environment holding a
+       rendering of the object.
+    '''
+    content = []
+
+    # Generate file name for current object
+    if 'img number' not in data.keys():
+        data['img number'] = 0
+
+    filename = os.path.join(data['output dir'],
+                            '%s_img%03d.png' % (data['base name'],
+                                                data['img number'])
+                            )
+    data['img number'] = data['img number'] + 1
+
+    # Get the dpi for rendering and store the original dpi of the figure
+    if data['dpi']:
+        dpi = data['dpi']
+    else:
+        dpi = mpl.rcParams['savefig.dpi']
+    fig_dpi = obj.figure.get_dpi()
+    obj.figure.set_dpi(dpi)
+
+    # Render the object and save as png file
+    cbox = obj.get_clip_box()
+    width = int(round(cbox.extents[2]))
+    height = int(round(cbox.extents[3]))
+    ren = backend_agg.RendererAgg(width, height, dpi)
+    obj.draw(ren)
+
+    # Generate a image from the render buffer
+    image = Image.frombuffer('RGBA', ren.get_canvas_width_height(),
+                             ren.buffer_rgba(), 'raw', 'RGBA', 0, 1)
+    # Crop the image to the actual content (removing the the regions otherwise
+    # used for axes, etc.)
+    # 'image.crop' expects the crop box to specify the left, upper, right, and
+    # lower pixel. 'cbox.extents' gives the left, lower, right, and upper pixel.
+    box = (int(round(cbox.extents[0])),
+           0,
+           int(round(cbox.extents[2])),
+           int(round(cbox.extents[3] - cbox.extents[1])))
+    cropped = image.crop(box)
+    cropped.save(filename)
+
+    # Restore the original dpi of the figure
+    obj.figure.set_dpi(fig_dpi)
+
+    # write the corresponding information to the TikZ file
+    extent = obj.axes.get_xlim() + obj.axes.get_ylim()
+
+    if data['rel data path']:
+        rel_filepath = os.path.join(data['rel data path'],
+                                    os.path.basename(filename)
+                                    )
+    else:
+        rel_filepath = os.path.basename(filename)
+
+    # Explicitly use \pgfimage as includegrapics command, as the default
+    # \includegraphics fails unexpectedly in some cases
+    content.append('\\addplot graphics [includegraphics cmd=\pgfimage,'
+                   'xmin=%.15g, xmax=%.15g, '
+                   'ymin=%.15g, ymax=%.15g] {%s};\n'
+                   % (extent + (rel_filepath,))
+                   )
+
+    return data, content

--- a/matplotlib2tikz/save.py
+++ b/matplotlib2tikz/save.py
@@ -4,6 +4,7 @@ from . import axes
 from . import legend
 from . import line2d
 from . import image as img
+from . import quadmesh as qmsh
 from . import path
 from . import patch
 from . import text as mytext
@@ -24,6 +25,7 @@ def save(filepath,
          draw_rectangles=False,
          wrap=True,
          extra=None,
+         dpi=None,
          show_info=True
          ):
     '''Main function. Here, the recursion into the image starts and the
@@ -93,6 +95,10 @@ def save(filepath,
                   Default is ``None``.
     :type extra: a set of strings for the pfgplots axes.
 
+    :param dpi: DPI settings for QuadMesh plots.
+                Default is ``None``.
+    :type dpi: int
+
     :returns: None
 
 
@@ -112,6 +118,7 @@ def save(filepath,
     data['fheight'] = figureheight
     data['rel data path'] = tex_relative_path_to_data
     data['output dir'] = os.path.dirname(filepath)
+    data['base name'] = os.path.splitext(os.path.basename(filepath))[0]
     data['strict'] = strict
     data['draw rectangles'] = draw_rectangles
     data['tikz libs'] = set()
@@ -122,6 +129,7 @@ def save(filepath,
         data['extra axis options'] = extra.copy()
     else:
         data['extra axis options'] = set()
+    data['dpi'] = dpi
 
     # open file
     import codecs
@@ -248,13 +256,15 @@ def _recurse(data, obj):
         elif isinstance(child, mpl.collections.LineCollection):
             data, cont = line2d.draw_linecollection(data, child)
             content.extend(cont)
+        elif isinstance(child, mpl.collections.QuadMesh):
+            data, cont = qmsh.draw_quadmesh(data, child)
+            content.extend(cont)
         elif isinstance(child, mpl.legend.Legend):
             data = legend.draw_legend(data, child)
         elif isinstance(child, mpl.axis.XAxis) or \
                 isinstance(child, mpl.axis.YAxis) or \
                 isinstance(child, mpl.spines.Spine) or \
-                isinstance(child, mpl.text.Text) or \
-                isinstance(child, mpl.collections.QuadMesh):
+                isinstance(child, mpl.text.Text):
             pass
         else:
             print('matplotlib2tikz: Don''t know how to handle object ''%s''.' %

--- a/matplotlib2tikz/save.py
+++ b/matplotlib2tikz/save.py
@@ -95,8 +95,9 @@ def save(filepath,
                   Default is ``None``.
     :type extra: a set of strings for the pfgplots axes.
 
-    :param dpi: DPI settings for QuadMesh plots.
-                Default is ``None``.
+    :param dpi: The resolution in dots per inch of the rendered image in case
+                of QuadMesh plots. If ``None`` it will default to the value
+                ``savefig.dpi`` from matplotlib.rcParams. Default is ``None``.
     :type dpi: int
 
     :returns: None
@@ -129,7 +130,10 @@ def save(filepath,
         data['extra axis options'] = extra.copy()
     else:
         data['extra axis options'] = set()
-    data['dpi'] = dpi
+    if dpi is None:
+        data['dpi'] = mpl.rcParams['savefig.dpi']
+    else:
+        data['dpi'] = dpi
 
     # open file
     import codecs

--- a/test/testfunctions/__init__.py
+++ b/test/testfunctions/__init__.py
@@ -18,6 +18,7 @@ __all__ = [
   'noise',
   'noise2',
   'patches',
+  'quadmesh',
   'scatter',
   'subplots',
   'subplot4x4',

--- a/test/testfunctions/quadmesh.py
+++ b/test/testfunctions/quadmesh.py
@@ -10,14 +10,13 @@ def plot():
 
     x = np.linspace(0*np.pi, 2*np.pi, 128)
     y = np.linspace(0*np.pi, 2*np.pi, 128)
-    X, Y = np.meshgrid(x,y)
+    X, Y = np.meshgrid(x, y)
     nu = 1e-5
     F = lambda t: np.exp(-2*nu*t)
-    u = lambda x,y,t:  np.sin(x)*np.cos(y)*F(t)
-    v = lambda x,y,t: -np.cos(x)*np.sin(y)*F(t)
+    u = lambda x, y, t:  np.sin(x)*np.cos(y)*F(t)
 
     fig, ax = plt.subplots()
-    p = ax.pcolormesh(X, Y, u(X,Y,0))
+    ax.pcolormesh(X, Y, u(X, Y, 0))
     ax.set_xlim(x[0], x[-1])
     ax.set_ylim(y[0], y[-1])
     ax.set_xlabel('x')

--- a/test/testfunctions/quadmesh.py
+++ b/test/testfunctions/quadmesh.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 desc = 'Plot Taylor--Green Vortex using pcolormesh'
-phash = 'ff6c26a669560546'
+phash = 'ff1a857849847ba2'
 
 
 def plot():

--- a/test/testfunctions/quadmesh.py
+++ b/test/testfunctions/quadmesh.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+#
+desc = 'Plot Taylor--Green Vortex using pcolormesh'
+phash = 'ff6c26a669560546'
+
+
+def plot():
+    from matplotlib import pyplot as plt
+    import numpy as np
+
+    x = np.linspace(0*np.pi, 2*np.pi, 128)
+    y = np.linspace(0*np.pi, 2*np.pi, 128)
+    X, Y = np.meshgrid(x,y)
+    nu = 1e-5
+    F = lambda t: np.exp(-2*nu*t)
+    u = lambda x,y,t:  np.sin(x)*np.cos(y)*F(t)
+    v = lambda x,y,t: -np.cos(x)*np.sin(y)*F(t)
+
+    fig, ax = plt.subplots()
+    p = ax.pcolormesh(X, Y, u(X,Y,0))
+    ax.set_xlim(x[0], x[-1])
+    ax.set_ylim(y[0], y[-1])
+    ax.set_xlabel('x')
+    ax.set_ylabel('y')
+    ax.set_title('Taylor--Green Vortex (u-velocity component)')
+
+    return fig

--- a/test/testfunctions/quadmesh.py
+++ b/test/testfunctions/quadmesh.py
@@ -14,13 +14,16 @@ def plot():
     nu = 1e-5
     F = lambda t: np.exp(-2*nu*t)
     u = lambda x, y, t:  np.sin(x)*np.cos(y)*F(t)
+    v = lambda x, y, t: -np.cos(x)*np.sin(y)*F(t)
 
-    fig, ax = plt.subplots()
-    ax.pcolormesh(X, Y, u(X, Y, 0))
-    ax.set_xlim(x[0], x[-1])
-    ax.set_ylim(y[0], y[-1])
-    ax.set_xlabel('x')
-    ax.set_ylabel('y')
-    ax.set_title('Taylor--Green Vortex (u-velocity component)')
+    fig, axs = plt.subplots(2, figsize=(8, 12))
+    axs[0].pcolormesh(X, Y, u(X, Y, 0))
+    axs[1].pcolormesh(X, Y, v(X, Y, 0))
+    for ax in axs:
+        ax.set_xlim(x[0], x[-1])
+        ax.set_ylim(y[0], y[-1])
+        ax.set_xlabel('x')
+        ax.set_ylabel('y')
+    axs[0].set_title('Taylor--Green Vortex')
 
     return fig


### PR DESCRIPTION
Add support for 'mpl.collections.QuadMesh', which are generated e.g. by 'plt.pcolormesh'.
The implementation relies on rendering the object using the AGG backend and save the image as png file.

A test for this (quadmesh.py) is included.

I believe this should also allow to close https://github.com/nschloe/matplotlib2tikz/pull/41, which seemed to implemented the same functionality in a similar way, however the code in https://github.com/nschloe/matplotlib2tikz/pull/41 is outdated and nonfunctional.