### PR TITLE
Fix error when using boxplot

### DIFF
--- a/matplotlib2tikz/line2d.py
+++ b/matplotlib2tikz/line2d.py
@@ -284,6 +284,7 @@ def _mpl_marker2pgfp_marker(data, mpl_marker, marker_face_color):
 _MPLLINESTYLE_2_PGFPLOTSLINESTYLE = {
     '': None,
     'None': None,
+    'none': None,  # happens when using plt.boxplot()
     '-': None,
     ':': 'dotted',
     '--': 'dashed',


### PR DESCRIPTION
When using [Matplotlib's boxplot](http://matplotlib.org/examples/pylab_examples/boxplot_demo.html) I get: 
```
  File "/usr/local/lib/python3.4/dist-packages/matplotlib2tikz/save.py", line 146, in save
    data, content = _recurse(data, figure)
  File "/usr/local/lib/python3.4/dist-packages/matplotlib2tikz/save.py", line 226, in _recurse
    data, children_content = _recurse(data, child)
  File "/usr/local/lib/python3.4/dist-packages/matplotlib2tikz/save.py", line 235, in _recurse
    data, cont = line2d.draw_line2d(data, child)
  File "/usr/local/lib/python3.4/dist-packages/matplotlib2tikz/line2d.py", line 30, in draw_line2d
    show_line, linestyle = _mpl_linestyle2pgfp_linestyle(obj.get_linestyle())
  File "/usr/local/lib/python3.4/dist-packages/matplotlib2tikz/line2d.py", line 299, in _mpl_linestyle2pgfp_linestyle
    style = _MPLLINESTYLE_2_PGFPLOTSLINESTYLE[line_style]
KeyError: 'none'
```

This bug is fixed with this pull request and I was able to generate boxplots for inclusion in LaTeX.