### PR TITLE
Bugfix for image: origin was ignored

### DIFF
--- a/matplotlib2tikz/image.py
+++ b/matplotlib2tikz/image.py
@@ -33,7 +33,8 @@ def draw_image(data, obj):
                           arr=img_array,
                           cmap=obj.get_cmap(),
                           vmin=clims[0],
-                          vmax=clims[1]
+                          vmax=clims[1],
+                          origin=obj.origin
                           )
     else:
         # RGB (+alpha) information at each point


### PR DESCRIPTION
The tex_relative_path_to_data was ignored while saving images.
The property origin of an image was ignored.

I'm not sure how to consider the origin flag in the else path, where PIL.Image.fromarray(...).save(...) is used.

I hope that this PR work also for Python2.