### PR TITLE
Suggestion: replace image filename

### DIFF
--- a/matplotlib2tikz/image.py
+++ b/matplotlib2tikz/image.py
@@ -18,9 +18,10 @@ def draw_image(data, obj):
     file_exists = True
     while file_exists:
         data['img number'] = data['img number'] + 1
-        filename = os.path.join(data['output dir'],
-                                'img' + str(data['img number']) + '.png'
-                                )
+        filename = os.path.join(
+            data['output dir'],
+            data['base name'] + str(data['img number']) + '.png'
+        )
         file_exists = os.path.isfile(filename)
 
     # store the image as in a file


### PR DESCRIPTION
When a plot with an image is saved, a file called "img1.png" is saved.
My suggestion ist, to save it as data['base name']'1.png', so the corresponding tikz file can be easily located.