### PR TITLE
Add ability to render bar charts and legends for bar charts

### DIFF
--- a/matplotlib2tikz/patch.py
+++ b/matplotlib2tikz/patch.py
@@ -51,14 +51,36 @@ def draw_patchcollection(data, obj):
 def _draw_rectangle(data, obj, draw_options):
     '''Return the PGFPlots code for rectangles.
     '''
-    if not data['draw rectangles']:
+
+    # Objects with labels are plot objects (from bar charts, etc).
+    # Even those without labels explicitly set have a label of
+    # "_nolegend_".  Everything else should be skipped because
+    # they likely correspong to axis/legend objects which are
+    # handled by PGFPlots
+    label = obj.get_label()
+    if label == '':
         return data, []
+
+    # get real label, bar charts by default only give rectangles
+    # labels of "_nolegend_"
+    # See http://stackoverflow.com/questions/35881290/how-to-get-the-label-on-bar-plot-stacked-bar-plot-in-matplotlib
+    handles,labels = obj.axes.get_legend_handles_labels()
+    labelsFound = [label for h,label in zip(handles, labels) if obj in h.get_children()]
+    if len(labelsFound) == 1:
+        label = labelsFound[0]
+
+    legend = ''
+    if label != '_nolegend_' and label not in data['rectangle_legends']:
+        data['rectangle_legends'].add(label)
+        legend = ('\\addlegendimage{ybar,ybar legend,%s};\n'
+                 ) % (','.join(draw_options))
 
     left_lower_x = obj.get_x()
     left_lower_y = obj.get_y()
-    cont = ('\draw[%s] (axis cs:%.15g,%.15g) '
+    cont = ('%s\draw[%s] (axis cs:%.15g,%.15g) '
             'rectangle (axis cs:%.15g,%.15g);\n'
-            ) % (','.join(draw_options),
+            ) % (legend,
+                 ','.join(draw_options),
                  left_lower_x,
                  left_lower_y,
                  left_lower_x + obj.get_width(),

--- a/matplotlib2tikz/save.py
+++ b/matplotlib2tikz/save.py
@@ -126,6 +126,10 @@ def save(filepath,
     data['pgfplots libs'] = set()
     data['font size'] = textsize
     data['custom colors'] = {}
+    # rectangle_legends is used to keep track of which rectangles have already
+    # had \addlegendimage added. There should be only one \addlegenimage per 
+    # bar chart data series.
+    data['rectangle_legends'] = set()
     if extra:
         data['extra axis options'] = extra.copy()
     else:

--- a/matplotlib2tikz/save.py
+++ b/matplotlib2tikz/save.py
@@ -22,7 +22,6 @@ def save(filepath,
          textsize=10.0,
          tex_relative_path_to_data=None,
          strict=False,
-         draw_rectangles=False,
          wrap=True,
          extra=None,
          dpi=None,
@@ -75,16 +74,6 @@ def save(filepath,
                    can decide where to put the ticks.
     :type strict: bool
 
-    :param draw_rectangles: Whether or not to draw Rectangle objects.
-                            You normally don't want that as legend, axes, and
-                            other entities which are natively taken care of by
-                            PGFPlots are represented as rectangles in
-                            matplotlib. Some plot types (such as bar plots)
-                            cannot otherwise be represented though.
-                            Don't expect working or clean output when using
-                            this option.
-    :type draw_rectangles: bool
-
     :param wrap: Whether ``'\\begin{tikzpicture}'`` and
                  ``'\\end{tikzpicture}'`` will be written. One might need to
                  provide custom arguments to the environment (eg. scale= etc.).
@@ -121,7 +110,6 @@ def save(filepath,
     data['output dir'] = os.path.dirname(filepath)
     data['base name'] = os.path.splitext(os.path.basename(filepath))[0]
     data['strict'] = strict
-    data['draw rectangles'] = draw_rectangles
     data['tikz libs'] = set()
     data['pgfplots libs'] = set()
     data['font size'] = textsize

--- a/test/test_hashes.py
+++ b/test/test_hashes.py
@@ -32,7 +32,6 @@ def test_hash(name):
         figureheight='7.5cm',
         show_info=True,
         strict=True,
-        draw_rectangles=True
         )
 
     # save reference figure

--- a/test/testfunctions/__init__.py
+++ b/test/testfunctions/__init__.py
@@ -4,6 +4,7 @@ __all__ = [
   'annotate',
   'basic_sin',
   'boxplot',
+  'barchart_legend',
   'barchart',
   'dual_axis',
   'errorband',

--- a/test/testfunctions/__init__.py
+++ b/test/testfunctions/__init__.py
@@ -4,6 +4,7 @@ __all__ = [
   'annotate',
   'basic_sin',
   'boxplot',
+  'barchart',
   'dual_axis',
   'errorband',
   'errorbar',

--- a/test/testfunctions/barchart.py
+++ b/test/testfunctions/barchart.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+""" Bar Chart test
+
+This tests plots a simple bar chart.  Bar charts are plotted as
+rectangle patches witch are difficult to tell from other rectangle
+patches that should not be plotted in PGFPlots (e.g. axis, legend)
+
+"""
+desc = 'Bar Chart'
+phash = '5f09a9e633728dc4'
+
+def plot():
+    import matplotlib.pyplot as plt
+    import numpy as np
+
+    # plot data
+    fig = plt.figure()
+    ax = fig.add_subplot(111)
+
+    x = np.arange(3)
+    y1 = [1, 2, 3]
+    y2 = [3, 2, 4]
+    y3 = [5, 3, 1]
+    w = 0.25
+
+    ax.bar(x-w, y1, w, color='b', align='center', label='Data 1')
+    ax.bar(x,   y2, w, color='g', align='center', label='Data 2')
+    ax.bar(x+w, y3, w, color='r', align='center', label='Data 3')
+    ax.legend()
+
+    return fig
+

--- a/test/testfunctions/barchart_legend.py
+++ b/test/testfunctions/barchart_legend.py
@@ -1,13 +1,17 @@
 # -*- coding: utf-8 -*-
-""" Bar Chart test
+""" Bar Chart Legend test
 
 This tests plots a simple bar chart.  Bar charts are plotted as
 rectangle patches witch are difficult to tell from other rectangle
 patches that should not be plotted in PGFPlots (e.g. axis, legend)
 
+This also tests legends on barcharts. Which are difficult because
+in PGFPlots, they have no \\addplot, and thus legend must be 
+manually added.
+
 """
 desc = 'Bar Chart'
-phash = '5f09a9e6b3728742'
+phash = '5f09a9e633728dc4'
 
 def plot():
     import matplotlib.pyplot as plt
@@ -23,9 +27,10 @@ def plot():
     y3 = [5, 3, 1]
     w = 0.25
 
-    ax.bar(x-w, y1, w, color='b', align='center')
-    ax.bar(x,   y2, w, color='g', align='center')
-    ax.bar(x+w, y3, w, color='r', align='center')
+    ax.bar(x-w, y1, w, color='b', align='center', label='Data 1')
+    ax.bar(x,   y2, w, color='g', align='center', label='Data 2')
+    ax.bar(x+w, y3, w, color='r', align='center', label='Data 3')
+    ax.legend()
 
     return fig
 


### PR DESCRIPTION
Hello again.  This PR is a bit more complicated and may have to be modified before you are likely to accept it.

I was looking to add the ability to render bar charts.   Even with draw_rectangles turned on, I had Latex errors, and even if that worked, the legend would not be drawn appropriately.

There are two major changes here:
1. Rectangles with a label are draw (ignoring draw_rectangles). It seems to me, rectangles with labels (although they are typically set to '_nolegend_' ) are associated with a plot and should be drawn.
2. Since bar charts have no \addplot associated, a legend must be added manually with \addlegendimage 
  From page 249 of the PGFPlots manual: 

    > Use \addlegendimage to provide custom styles into legends, for example to document custom \draw
commands inside of an axis.
 
    So, I set it up so that the first rectangle of each label has an \addlegendimage added

One confusing part is getting the legend label associated with the rectangle.  For that, see  [this](http://stackoverflow.com/questions/35881290/how-to-get-the-label-on-bar-plot-stacked-bar-plot-in-matplotlib) discussion.

The barchart test output (showing working legends):
![barchartjtffuz-1](https://cloud.githubusercontent.com/assets/5289854/22603110/0ef97d0c-ea14-11e6-81f1-1af8d1088bc9.png)

The reference:
![reference](https://cloud.githubusercontent.com/assets/5289854/22603179/4cef247c-ea14-11e6-980c-5e24b47441d9.png)


