### PR TITLE
Respect Z-Orders

### DIFF
--- a/matplotlib2tikz/save.py
+++ b/matplotlib2tikz/save.py
@@ -215,12 +215,35 @@ def _print_pgfplot_libs_message(data):
     print('=========================================================')
     return
 
+class _ContentManager(object):
+    """ Basic Content Manager for matplotlib2tikz 
+
+    This manager uses a dictionary to map z-order to an array of content
+    to be drawn at the z-order.
+    """
+    def __init__(self):
+        self._content = dict()
+
+    def extend(self, content, zorder):
+        """ Extends with a list and a z-order
+        """
+        if zorder not in self._content:
+            self._content[zorder] = []
+        self._content[zorder].extend(content)
+
+    def flatten(self):
+        content_out = []
+        all_z = sorted(self._content.keys())
+        for z in all_z:
+            content_out.extend(self._content[z])
+        return content_out
+
 
 def _recurse(data, obj):
     '''Iterates over all children of the current object, gathers the contents
     contributing to the resulting PGFPlots file, and returns those.
     '''
-    content = []
+    content = _ContentManager()
     for child in obj.get_children():
         if isinstance(child, mpl.axes.Axes):
             # Reset 'extra axis options' for every new Axes environment.
@@ -234,34 +257,35 @@ def _recurse(data, obj):
                 if data['extra axis options']:
                     ax.axis_options.extend(data['extra axis options'])
                 # populate content
-                content.extend(ax.get_begin_code())
-                content.extend(children_content)
-                content.extend(ax.get_end_code(data))
+                content.extend(
+                        ax.get_begin_code() + 
+                        children_content +
+                        [ax.get_end_code(data)], 0)
         elif isinstance(child, mpl.lines.Line2D):
             data, cont = line2d.draw_line2d(data, child)
-            content.extend(cont)
+            content.extend(cont, child.get_zorder())
         elif isinstance(child, mpl.image.AxesImage):
             data, cont = img.draw_image(data, child)
-            content.extend(cont)
+            content.extend(cont, child.get_zorder())
             # # Really necessary?
             # data, children_content = _recurse(data, child)
             # content.extend(children_content)
         elif isinstance(child, mpl.patches.Patch):
             data, cont = patch.draw_patch(data, child)
-            content.extend(cont)
+            content.extend(cont, child.get_zorder())
         elif isinstance(child, mpl.collections.PatchCollection) or \
                 isinstance(child, mpl.collections.PolyCollection):
             data, cont = patch.draw_patchcollection(data, child)
-            content.extend(cont)
+            content.extend(cont, child.get_zorder())
         elif isinstance(child, mpl.collections.PathCollection):
             data, cont = path.draw_pathcollection(data, child)
-            content.extend(cont)
+            content.extend(cont, child.get_zorder())
         elif isinstance(child, mpl.collections.LineCollection):
             data, cont = line2d.draw_linecollection(data, child)
-            content.extend(cont)
+            content.extend(cont, child.get_zorder())
         elif isinstance(child, mpl.collections.QuadMesh):
             data, cont = qmsh.draw_quadmesh(data, child)
-            content.extend(cont)
+            content.extend(cont, child.get_zorder())
         elif isinstance(child, mpl.legend.Legend):
             data = legend.draw_legend(data, child)
         elif isinstance(child, mpl.axis.XAxis) or \
@@ -276,5 +300,5 @@ def _recurse(data, obj):
     if isinstance(obj, mpl.axes.Subplot) or isinstance(obj, mpl.figure.Figure):
         for text in obj.texts:
             data, cont = mytext.draw_text(data, text)
-            content.extend(cont)
-    return data, content
+            content.extend(cont, text.get_zorder())
+    return data, content.flatten()

--- a/test/testfunctions/__init__.py
+++ b/test/testfunctions/__init__.py
@@ -5,6 +5,7 @@ __all__ = [
   'basic_sin',
   'boxplot',
   'barchart_legend',
+  'barchart_errorbars',
   'barchart',
   'dual_axis',
   'errorband',

--- a/test/testfunctions/barchart_errorbars.py
+++ b/test/testfunctions/barchart_errorbars.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+""" Bar Chart With Errorbar test
+
+This tests plots a bar chart with error bars.  The errorbars need to be drawn
+at the correct z-order to be sucessful.
+
+"""
+desc = 'Bar Chart With Errorbars'
+phash = '5f09a9e4b37287c2'
+
+def plot():
+    import matplotlib.pyplot as plt
+    import numpy as np
+
+    # plot data
+    fig = plt.figure()
+    ax = fig.add_subplot(111)
+
+    x = np.arange(3)
+    y1 = [1, 2, 3]
+    y1err = [0.1, 0.2, 0.5]
+    y2 = [3, 2, 4]
+    y2err = [0.4, 0.2, 0.5]
+    y3 = [5, 3, 1]
+    y3err = [0.1, 0.2, 0.1]
+    w = 0.25
+
+    errBarStyle = dict(ecolor='black', lw=5, capsize=8, capthick=5)
+
+    ax.bar(x-w, y1, w, color='b', yerr=y1err, align='center', error_kw=errBarStyle)
+    ax.bar(x,   y2, w, color='g', yerr=y2err, align='center', error_kw=errBarStyle)
+    ax.bar(x+w, y3, w, color='r', yerr=y3err, align='center', error_kw=errBarStyle)
+
+    return fig
+

--- a/test/testfunctions/fancybox.py
+++ b/test/testfunctions/fancybox.py
@@ -8,7 +8,7 @@ from matplotlib.patches import FancyBboxPatch
 
 desc = 'Fancybox'
 # phash = 'dd232dd0239dd85a'
-phash = '9d2325dc23cdd85a'
+phash = '9d2327dc23cdd81a'
 
 
 # Bbox object around which the fancy box will be drawn.


### PR DESCRIPTION
Change to respect the z-orders of objects.  The basic idea was instead of just storing the content to be written out to file in an array, maintain it in a dictionary that maps z-order to an array of content for that z-order.  Then flatten it into a single content array using the z-order.  This flattening does occur a couple times (for example all axes objects must be flattened so they can be book ended by `\begin{axis}` and `\end{axis}` correctly.

Before, bar charts with error bars were plotted as:
![barchart_errorbarsevx8q1-1_t1](https://cloud.githubusercontent.com/assets/5289854/22805645/8557d3d6-eeec-11e6-860c-1e12a47207cf.png)

Now:
![barchart_errorbarsidfigi-1](https://cloud.githubusercontent.com/assets/5289854/22805654/8e5f8a6e-eeec-11e6-8d8f-4a4681701ce2.png)

(The ugliness of these plots are to make sure there is a difference in the hashes, thin error bars weren't working)

