### PR TITLE
Take into account the visibility of ticklabels

### DIFF
--- a/matplotlib2tikz/axes.py
+++ b/matplotlib2tikz/axes.py
@@ -389,7 +389,10 @@ def _get_ticks(data, xy, ticks, ticklabels):
         pgfplots_ticks.append(tick)
         # store the label anyway
         label = ticklabel.get_text()
-        pgfplots_ticklabels.append(label)
+        if ticklabel.get_visible():
+            pgfplots_ticklabels.append(label)
+        else:
+            is_label_required = True
         # Check if the label is necessary. If one of the labels is, then all
         # of them must appear in the TikZ plot.
         if label:

--- a/test/testfunctions/__init__.py
+++ b/test/testfunctions/__init__.py
@@ -27,6 +27,7 @@ __all__ = [
   'quadmesh',
   'scatter',
   'scatter_colormap',
+  'sharex_and_y',
   'subplots',
   'subplot4x4',
   'subplots_with_colorbars',

--- a/test/testfunctions/legends2.py
+++ b/test/testfunctions/legends2.py
@@ -2,7 +2,7 @@
 #
 desc = 'Multiple legend positions'
 # phash = 'd558f444f0542bbb'
-phash = '55d47cd472d4892b'
+phash = '55d454d47ed4892b'
 
 
 def plot():

--- a/test/testfunctions/sharex_and_y.py
+++ b/test/testfunctions/sharex_and_y.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+#
+desc = 'Tick label visibility with sharex and sharey'
+phash = '9bed5812ff11a892'
+
+
+def plot():
+    from matplotlib import pyplot as pp
+    import numpy as np
+
+    fig, axes = pp.subplots(2, 2, sharex=True, sharey=True, figsize=(8, 5))
+    t = np.arange(0.0, 5.0, 0.01)
+    s = np.cos(2 * np.pi * t)
+
+    axes[0][0].plot(t, s, color='blue')
+    axes[0][1].plot(t, s, color='red')
+    axes[1][0].plot(t, s, color='green')
+    axes[1][1].plot(t, s, color='black')
+
+    return fig


### PR DESCRIPTION
Hi,
Just a small improvement related to the visibiliy of tick labels. 
For instance, when you draw subplots which share the same x and y axis, the ticklabels only appear at the bottom of the subplots' grid and at the left. With the code of the master branch, they are always plotted regardless their visibility parameter.
Regards.