### PR TITLE
Allow rotation of axes tick labels

### DIFF
--- a/matplotlib2tikz/axes.py
+++ b/matplotlib2tikz/axes.py
@@ -198,6 +198,35 @@ class Axes(object):
                     assert direction == 'inout'
                     self.axis_options.append('tick align=center')
 
+        # Set each rotation for every label
+        x_tick_labels_rotation = \
+            [label.get_rotation() for label in obj.xaxis.get_majorticklabels()]
+        if any(x_tick_labels_rotation) != 0:
+            # check if every value is the same
+            if len(set(x_tick_labels_rotation)) == 1:
+                self.axis_options.append('xticklabel style = {rotate=%d}' %
+                                         x_tick_labels_rotation[0])
+            else:
+                value = 'every x tick label/.style = {\n' \
+                    'rotate={,%s}[\\ticknum]\n' \
+                    '}' % ','.join(str(x) for x in x_tick_labels_rotation)
+
+                self.axis_options.append(value)
+
+        y_tick_labels_rotation = \
+            [label.get_rotation() for label in obj.yaxis.get_majorticklabels()]
+        if any(y_tick_labels_rotation) != 0:
+            # check if every value is the same
+            if len(set(y_tick_labels_rotation)) == 1:
+                self.axis_options.append('yticklabel style = {rotate=%d}' %
+                                         y_tick_labels_rotation[0])
+            else:
+                value = 'every y tick label/.style = {\n' \
+                    'rotate={,%s}[\\ticknum]\n' \
+                    '}' % ','.join(str(x) for x in y_tick_labels_rotation)
+
+                self.axis_options.append(value)
+
         # Don't use get_{x,y}gridlines for gridlines; see discussion on
         # <http://sourceforge.net/p/matplotlib/mailman/message/25169234/>
         # Coordinate of the lines are entirely meaningless, but styles

--- a/test/test_rotated_labels.py
+++ b/test/test_rotated_labels.py
@@ -1,0 +1,141 @@
+# -*- coding: utf-8 -*-
+#
+import matplotlib2tikz
+
+import pytest
+import tempfile
+import os
+from matplotlib import pyplot as plt
+
+
+def __plot():
+    fig, ax = plt.subplots()
+
+    x = [1, 2, 3, 4]
+    y = [1, 4, 9, 6]
+
+    plt.plot(x, y, 'ro')
+    plt.xticks(x, rotation='horizontal')
+
+    return fig, ax
+
+
+@pytest.mark.parametrize(
+    "x_alignment, y_alignment, x_tick_label_width,"
+    "y_tick_label_width, rotation", [
+        (None,     None,     "1rem", "3rem", 90),
+        (None,     "center", "1rem", "3rem", 90),
+        ("center", None,     "1rem", "3rem", 90),
+        ("center", "center", None,   "3rem", 90),
+        ("left",   "left",   None,   "3rem", 90),
+        ("right",  "right",  None,   "3rem", 90),
+        ("center", "center", "1rem", None,   90),
+        ("left",   "left",   "2rem", None,   90),
+        ("right",  "right",  "3rem", None,   90),
+        ("center", "center", "1rem", "3rem", 90),
+        ("left",   "left",   "2rem", "3rem", 90),
+        ("right",  "right",  "3rem", "3rem", 90),
+        ("left",   "right",  "2rem", "3rem", 90),
+        ("right",  "left",   "3rem", "3rem", 90),
+    ])
+def test_rotated_labels_parameters(x_alignment, y_alignment,
+                                   x_tick_label_width, y_tick_label_width,
+                                   rotation):
+    fig, _ = __plot()
+
+    if x_alignment:
+        plt.xticks(ha=x_alignment, rotation=rotation)
+    if y_alignment:
+        plt.yticks(ha=y_alignment, rotation=rotation)
+
+    # convert to tikz file
+    _, tmp_base = tempfile.mkstemp()
+    tikz_file = tmp_base + '_tikz.tex'
+
+    extra_dict = {}
+
+    if x_tick_label_width:
+        extra_dict['x tick label text width'] = x_tick_label_width
+    if y_tick_label_width:
+        extra_dict['y tick label text width'] = y_tick_label_width
+
+    matplotlib2tikz.save(
+        tikz_file,
+        figurewidth='7.5cm',
+        extra=extra_dict
+        )
+
+    # close figure
+    plt.close(fig)
+
+    # delete file
+    os.unlink(tikz_file)
+
+
+@pytest.mark.parametrize("x_tick_label_width, y_tick_label_width", [
+    (None,   None),
+    ("1rem", None),
+    (None,   "3rem"),
+    ("2rem", "3rem"),
+])
+def test_rotated_labels_parameters_different_values(x_tick_label_width,
+                                                    y_tick_label_width):
+    fig, ax = __plot()
+
+    plt.xticks(ha='left', rotation=90)
+    plt.yticks(ha='left', rotation=90)
+    ax.xaxis.get_majorticklabels()[0].set_rotation(20)
+    ax.yaxis.get_majorticklabels()[0].set_horizontalalignment('right')
+
+    # convert to tikz file
+    _, tmp_base = tempfile.mkstemp()
+    tikz_file = tmp_base + '_tikz.tex'
+
+    extra_dict = {}
+
+    if x_tick_label_width:
+        extra_dict['x tick label text width'] = x_tick_label_width
+    if y_tick_label_width:
+        extra_dict['y tick label text width'] = y_tick_label_width
+
+    matplotlib2tikz.save(
+        tikz_file,
+        figurewidth='7.5cm',
+        extra=extra_dict
+        )
+
+    # close figure
+    plt.close(fig)
+
+    # delete file
+    os.unlink(tikz_file)
+
+
+def test_rotated_labels_parameters_no_ticks():
+    fig, ax = __plot()
+
+    ax.xaxis.set_ticks([])
+
+    plt.tick_params(axis='x',
+                    which='both',
+                    bottom='off',
+                    top='off')
+    plt.tick_params(axis='y',
+                    which='both',
+                    left='off',
+                    right='off')
+
+    # convert to tikz file
+    _, tmp_base = tempfile.mkstemp()
+    tikz_file = tmp_base + '_tikz.tex'
+
+    matplotlib2tikz.save(
+        tikz_file,
+        figurewidth='7.5cm'
+        )
+
+    # close figure
+    plt.close(fig)
+
+    # delete file
+    os.unlink(tikz_file)

--- a/test/testfunctions/__init__.py
+++ b/test/testfunctions/__init__.py
@@ -26,6 +26,7 @@ __all__ = [
   'patches',
   'quadmesh',
   'rotated_labels',
+  'tick_positions',
   'scatter',
   'scatter_colormap',
   'sharex_and_y',

--- a/test/testfunctions/__init__.py
+++ b/test/testfunctions/__init__.py
@@ -25,6 +25,7 @@ __all__ = [
   'noise2',
   'patches',
   'quadmesh',
+  'rotated_labels',
   'scatter',
   'scatter_colormap',
   'sharex_and_y',

--- a/test/testfunctions/annotate.py
+++ b/test/testfunctions/annotate.py
@@ -2,7 +2,7 @@
 #
 desc = 'Annotations'
 # phash = 'ab8a78a1549654fe'
-phash = 'ab8a71a1569654de'
+phash = 'ab8a79a1549654be'
 
 
 def plot():

--- a/test/testfunctions/barchart.py
+++ b/test/testfunctions/barchart.py
@@ -7,7 +7,8 @@ patches that should not be plotted in PGFPlots (e.g. axis, legend)
 
 """
 desc = 'Bar Chart'
-phash = '5f09a9e6b3728742'
+phash = '5f09a9e6b172874a'
+
 
 def plot():
     import matplotlib.pyplot as plt

--- a/test/testfunctions/barchart_errorbars.py
+++ b/test/testfunctions/barchart_errorbars.py
@@ -6,7 +6,8 @@ at the correct z-order to be sucessful.
 
 """
 desc = 'Bar Chart With Errorbars'
-phash = '5f09a9e4b37287c2'
+phash = '5f09a9e6b1728746'
+
 
 def plot():
     import matplotlib.pyplot as plt

--- a/test/testfunctions/barchart_legend.py
+++ b/test/testfunctions/barchart_legend.py
@@ -6,12 +6,13 @@ rectangle patches witch are difficult to tell from other rectangle
 patches that should not be plotted in PGFPlots (e.g. axis, legend)
 
 This also tests legends on barcharts. Which are difficult because
-in PGFPlots, they have no \\addplot, and thus legend must be 
+in PGFPlots, they have no \\addplot, and thus legend must be
 manually added.
 
 """
 desc = 'Bar Chart'
-phash = '5f09a9e633728dc4'
+phash = '5f19a966937285cc'
+
 
 def plot():
     import matplotlib.pyplot as plt

--- a/test/testfunctions/basic_sin.py
+++ b/test/testfunctions/basic_sin.py
@@ -2,7 +2,7 @@
 #
 desc = 'Simple $\sin$ plot with some labels'
 # phash = '5f34e1ce21c3e5c1'
-phash = '1f36e1ce21c1e7c1'
+phash = '1f36e5c621c1e7c1'
 
 
 def plot():

--- a/test/testfunctions/boxplot.py
+++ b/test/testfunctions/boxplot.py
@@ -3,12 +3,13 @@
 
 This test plots a box plot with three data series. The causes an empty Line2D
 to be plotted.  Without care, this can turn into an empty table in PGFPlot
-which crashes latex (due to it treating an empty table as a table with 
+which crashes latex (due to it treating an empty table as a table with
 external data in the file '' or '.tex')
 See: https://github.com/nschloe/matplotlib2tikz/pull/134
 """
 desc = 'BoxPlot'
-phash = '6bc6f6b95e0000fe'
+phash = '6be3e6b95e8000de'
+
 
 def plot():
     import matplotlib.pyplot as plt

--- a/test/testfunctions/dual_axis.py
+++ b/test/testfunctions/dual_axis.py
@@ -2,7 +2,7 @@
 #
 desc = 'Dual axis plot'
 # phash = '43a35c4b76a94eb8'
-phash = '5bab54492628de7c'
+phash = '5382544c16bdde75'
 
 
 def plot():

--- a/test/testfunctions/errorband.py
+++ b/test/testfunctions/errorband.py
@@ -3,7 +3,7 @@
 desc = 'Simple $\sin$ plot with an errorband, which generates an \
         mpl.collections.PolyCollection'
 # phash = 'af2cd712256457ac'
-phash = '6f2c9d922172672d'
+phash = 'af2cd5922172772c'
 
 
 def plot():

--- a/test/testfunctions/errorbar.py
+++ b/test/testfunctions/errorbar.py
@@ -2,7 +2,7 @@
 #
 desc = 'Errorbars'
 # phash = 'a3535ca5bcac5698'
-phash = 'a3535c24beac76b0'
+phash = 'a3435e25bea866b8'
 
 
 def plot():

--- a/test/testfunctions/fillstyle.py
+++ b/test/testfunctions/fillstyle.py
@@ -2,7 +2,7 @@
 #
 desc = 'fillstyle "none"'
 # phash = '015752594e6d3ebc'
-phash = 'a103fa59ee613e94'
+phash = 'a103fa09ee613e9e'
 
 
 def plot():

--- a/test/testfunctions/legends.py
+++ b/test/testfunctions/legends.py
@@ -2,7 +2,7 @@
 #
 desc = 'Plot with legends'
 # phash = 'fdfc810697a10e2b'
-phash = '7ffca10386d10e6a'
+phash = '7f7ca18386d10eaa'
 
 
 def plot():

--- a/test/testfunctions/legends2.py
+++ b/test/testfunctions/legends2.py
@@ -2,7 +2,7 @@
 #
 desc = 'Multiple legend positions'
 # phash = 'd558f444f0542bbb'
-phash = '55d454d47ed4892b'
+phash = '55d45cd47ad4812f'
 
 
 def plot():

--- a/test/testfunctions/line_collection.py
+++ b/test/testfunctions/line_collection.py
@@ -2,7 +2,7 @@
 #
 desc = 'Line collection'
 # phash = '4b56b5b5b45ca4a2'
-phash = '4b42b5bdb45ca4e2'
+phash = '4b52b5bdb45ca462'
 
 
 def plot():

--- a/test/testfunctions/loglogplot.py
+++ b/test/testfunctions/loglogplot.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 #
 desc = 'Loglog plot with large ticks dimensions'
-#phash = 'c103fa59ce6f3e80'
-phash = 'ebc35e096e21bec0'
+# phash = 'c103fa59ce6f3e80'
+phash = 'abc35ec96e21be80'
 
 
 def plot():

--- a/test/testfunctions/logplot.py
+++ b/test/testfunctions/logplot.py
@@ -2,7 +2,7 @@
 #
 desc = 'Log scaled plot'
 # phash = 'ab037e097e29ff00'
-phash = 'e1ea7eea7e6c1400'
+phash = 'e9e25eea7eea1400'
 
 
 def plot():

--- a/test/testfunctions/noise.py
+++ b/test/testfunctions/noise.py
@@ -2,7 +2,7 @@
 #
 desc = 'Noise with a color bar'
 # phash = 'f54b0ba50bb10bf4'
-phash = 'fd5a0bb503f50354'
+phash = 'f55a0bb503fd0354'
 
 
 def plot():

--- a/test/testfunctions/quadmesh.py
+++ b/test/testfunctions/quadmesh.py
@@ -2,7 +2,7 @@
 #
 desc = 'Plot Taylor--Green Vortex using pcolormesh'
 # phash = 'ff1a8578c9847b22'
-phash = '7f1a8578c9857932'
+phash = '7f1a8578498579b2'
 
 
 def plot():

--- a/test/testfunctions/rotated_labels.py
+++ b/test/testfunctions/rotated_labels.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 desc = 'Rotated labels'
-phash = 'a91fa323753d8d03'
+phash = 'a91fa2a3713dcc0b'
 
 
 def plot():

--- a/test/testfunctions/rotated_labels.py
+++ b/test/testfunctions/rotated_labels.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+
+desc = 'Rotated labels'
+phash = 'a91fa323753d8d03'
+
+
+def plot():
+    from matplotlib import pyplot as plt
+
+    x = [1, 2, 3, 4]
+    y = [1, 4, 9, 6]
+
+    fig = plt.figure()
+
+    plt.subplot(611)
+    plt.plot(x, y, 'ro')
+    plt.xticks(x, rotation='horizontal')
+
+    plt.subplot(612)
+    plt.plot(x, y, 'ro')
+    plt.xticks(x, rotation='vertical')
+
+    ax = plt.subplot(613)
+    ax.plot(x, y, 'ro')
+    plt.xticks(y, rotation=-25)
+
+    ax = plt.subplot(614)
+    ax.plot(x, y, 'ro')
+    plt.yticks(y, rotation=-25)
+
+    ax = plt.subplot(615)
+    ax.plot(x, y, 'ro')
+
+    for idx, label in enumerate(ax.get_xticklabels()):
+        label.set_rotation(45 if idx % 2 == 0 else 0)
+
+    ax = plt.subplot(616)
+    ax.plot(x, y, 'ro')
+
+    for idx, label in enumerate(ax.get_yticklabels()):
+        label.set_rotation(90 if idx % 2 == 0 else 0)
+
+    return fig

--- a/test/testfunctions/scatter.py
+++ b/test/testfunctions/scatter.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 #
 desc = 'Scatter plot'
-#phash = '5fd219cc653c85a5'
-phash = '5f425b484525bf95'
+# phash = '5fd219cc653c85a5'
+phash = '7f425b584d603f85'
 
 
 def plot():

--- a/test/testfunctions/scatter_colormap.py
+++ b/test/testfunctions/scatter_colormap.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 #
 desc = 'Scatter plot'
-#phash = 'cf316c4e70cc738c'
-phash = 'cb616ccae54c738c'
+# phash = 'cf316c4e70cc738c'
+phash = 'cb616c42e5ec738c'
 
 
 def plot():

--- a/test/testfunctions/sharex_and_y.py
+++ b/test/testfunctions/sharex_and_y.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 desc = 'Tick label visibility with sharex and sharey'
-phash = '9bed5812ff11a892'
+phash = '9bcdbc02ff919812'
 
 
 def plot():

--- a/test/testfunctions/subplot4x4.py
+++ b/test/testfunctions/subplot4x4.py
@@ -2,7 +2,7 @@
 #
 desc = '$4\\times 4$ subplots'
 # phash = 'a19c3f529adc3313'
-phash = 'eb9c3f129edc0303'
+phash = 'ab9c3f52dadc0303'
 
 
 def plot():

--- a/test/testfunctions/subplots.py
+++ b/test/testfunctions/subplots.py
@@ -2,7 +2,7 @@
 #
 desc = 'Two subplots on top of each other'
 # phash = '5f219566e19d64c6'
-phash = '1f21d53629de26c6'
+phash = '1f21c53639de26c6'
 
 
 def plot():

--- a/test/testfunctions/subplots_with_colorbars.py
+++ b/test/testfunctions/subplots_with_colorbars.py
@@ -2,7 +2,7 @@
 #
 desc = 'Subplots with colorbars'
 # phash = '6bc03fc02a9fc03f'
-phash = '6bc42fd02b95c03f'
+phash = '6bc42fd06a95c03f'
 
 
 def plot():

--- a/test/testfunctions/text_overlay.py
+++ b/test/testfunctions/text_overlay.py
@@ -2,7 +2,7 @@
 #
 desc = 'Regular plot with overlay text'
 # phash = '770b23744b93c68d'
-phash = '370b233649d3f64c'
+phash = '37092b3649d3f64c'
 
 
 def plot():

--- a/test/testfunctions/tick_positions.py
+++ b/test/testfunctions/tick_positions.py
@@ -1,0 +1,95 @@
+# -*- coding: utf-8 -*-
+
+desc = 'Tick positioffs'
+phash = 'cfa200af41ef40ef'
+
+
+def plot():
+    from matplotlib import pyplot as plt
+
+    x = [1, 2, 3, 4]
+    y = [1, 4, 9, 6]
+
+    fig = plt.figure()
+
+    ax = plt.subplot(4, 4, 1)
+    plt.plot(x, y, 'ro')
+    plt.tick_params(axis='x', which='both', bottom='off', top='off')
+    plt.tick_params(axis='y', which='both', left='off', right='off')
+
+    ax = plt.subplot(4, 4, 2)
+    plt.plot(x, y, 'ro')
+    plt.tick_params(axis='x', which='both', bottom='off', top='off')
+    plt.tick_params(axis='y', which='both', left='off', right='on')
+
+    ax = plt.subplot(4, 4, 3)
+    plt.plot(x, y, 'ro')
+    plt.tick_params(axis='x', which='both', bottom='off', top='off')
+    plt.tick_params(axis='y', which='both', left='on', right='off')
+
+    ax = plt.subplot(4, 4, 4)
+    ax.plot(x, y, 'ro')
+    plt.tick_params(axis='x', which='both', bottom='off', top='off')
+    plt.tick_params(axis='y', which='both', left='on', right='on')
+
+    ax = plt.subplot(4, 4, 5)
+    ax.plot(x, y, 'ro')
+    plt.tick_params(axis='x', which='both', bottom='off', top='on')
+    plt.tick_params(axis='y', which='both', left='off', right='off')
+
+    ax = plt.subplot(4, 4, 6)
+    plt.plot(x, y, 'ro')
+    plt.tick_params(axis='x', which='both', bottom='off', top='on')
+    plt.tick_params(axis='y', which='both', left='off', right='on')
+
+    ax = plt.subplot(4, 4, 7)
+    plt.plot(x, y, 'ro')
+    plt.tick_params(axis='x', which='both', bottom='off', top='on')
+    plt.tick_params(axis='y', which='both', left='on', right='off')
+
+    ax = plt.subplot(4, 4, 8)
+    ax.plot(x, y, 'ro')
+    plt.tick_params(axis='x', which='both', bottom='off', top='on')
+    plt.tick_params(axis='y', which='both', left='on', right='on')
+
+    ax = plt.subplot(4, 4, 9)
+    ax.plot(x, y, 'ro')
+    plt.tick_params(axis='x', which='both', bottom='on', top='off')
+    plt.tick_params(axis='y', which='both', left='off', right='off')
+
+    ax = plt.subplot(4, 4, 10)
+    plt.plot(x, y, 'ro')
+    plt.tick_params(axis='x', which='both', bottom='on', top='off')
+    plt.tick_params(axis='y', which='both', left='off', right='on')
+
+    ax = plt.subplot(4, 4, 11)
+    plt.plot(x, y, 'ro')
+    plt.tick_params(axis='x', which='both', bottom='on', top='off')
+    plt.tick_params(axis='y', which='both', left='on', right='off')
+
+    ax = plt.subplot(4, 4, 12)
+    ax.plot(x, y, 'ro')
+    plt.tick_params(axis='x', which='both', bottom='on', top='off')
+    plt.tick_params(axis='y', which='both', left='on', right='on')
+
+    ax = plt.subplot(4, 4, 13)
+    ax.plot(x, y, 'ro')
+    plt.tick_params(axis='x', which='both', bottom='on', top='on')
+    plt.tick_params(axis='y', which='both', left='off', right='off')
+
+    ax = plt.subplot(4, 4, 14)
+    ax.plot(x, y, 'ro')
+    plt.tick_params(axis='x', which='both', bottom='on', top='on')
+    plt.tick_params(axis='y', which='both', left='off', right='on')
+
+    ax = plt.subplot(4, 4, 15)
+    ax.plot(x, y, 'ro')
+    plt.tick_params(axis='x', which='both', bottom='on', top='on')
+    plt.tick_params(axis='y', which='both', left='on', right='off')
+
+    ax = plt.subplot(4, 4, 16)
+    ax.plot(x, y, 'ro')
+    plt.tick_params(axis='x', which='both', bottom='on', top='on')
+    plt.tick_params(axis='y', which='both', left='on', right='on')
+
+    return fig


### PR DESCRIPTION
This patch allows arbitrary rotation of tick labels. If the rotation is the same for every label on the given axes, it will apply a global `xticklabel style`. If the rotation values differs, it will create an array of the rotation value and apply the one at the given tick index.

In addition, I've attached a small test set with different rotated labels on both, the x and y axes.