### PR TITLE
Fix tick label text width caused by formatting

### DIFF
--- a/matplotlib2tikz/axes.py
+++ b/matplotlib2tikz/axes.py
@@ -387,8 +387,8 @@ class Axes(object):
         tick_label_text_width = None
         tick_label_text_width_identifier = "%s tick label text width" % axes
         if tick_label_text_width_identifier in data['extra axis options']:
-            tick_label_text_width = data['extra axis options [base]']
-            [tick_label_text_width_identifier]
+            tick_label_text_width = data['extra axis options [base]'] \
+                [tick_label_text_width_identifier]
             del data['extra axis options'][tick_label_text_width_identifier]
 
         label_style = ""


### PR DESCRIPTION
By formatting the code to conform to PEP8, I forgot a backslash
causing a misbehavior. This patch fixes that, as otherwise the whole
dictionary would have been set to the variable instead of only
one value it contains.