### PR TITLE
Return 'none' when alpha value is 0

### DIFF
--- a/matplotlib2tikz/color.py
+++ b/matplotlib2tikz/color.py
@@ -10,8 +10,12 @@ def mpl_color2xcolor(data, matplotlib_color):
     # Convert it to RGBA.
     my_col = numpy.array(mpl.colors.ColorConverter().to_rgba(matplotlib_color))
 
-    xcol = None
+    # If the alpha channel is exactly 0, then the color is really 'none'
+    # regardless of the RGB channels.
+    if my_col[-1] == 0.0:
+        return data, 'none', my_col
 
+    xcol = None
     # RGB values (as taken from xcolor.dtx):
     available_colors = {
         'red':  numpy.array([1, 0, 0]),


### PR DESCRIPTION
A simple fix that in `color.py` where `mpl_color2xcolor` returns `none` when the alpha value is exactly zero.