### PR TITLE
Fix ignored minor grid if major grid is true in axes object

### DIFF
--- a/matplotlib2tikz/axes.py
+++ b/matplotlib2tikz/axes.py
@@ -225,7 +225,7 @@ class Axes(object):
         # pylint: disable=protected-access
         if obj.xaxis._gridOnMajor:
             self.axis_options.append('xmajorgrids')
-        elif obj.xaxis._gridOnMinor:
+        if obj.xaxis._gridOnMinor:
             self.axis_options.append('xminorgrids')
 
         xlines = obj.get_xgridlines()
@@ -238,7 +238,7 @@ class Axes(object):
         # pylint: disable=protected-access
         if obj.yaxis._gridOnMajor:
             self.axis_options.append('ymajorgrids')
-        elif obj.yaxis._gridOnMinor:
+        if obj.yaxis._gridOnMinor:
             self.axis_options.append('yminorgrids')
 
         ylines = obj.get_ygridlines()


### PR DESCRIPTION
If an axes has a minor grid this grid is not displayed in tex, because the matplotlib axes object's property for the major grid is also true. Therefore the minorgrid property will never be added.