### PR TITLE
added a few options to allow not exporting some parameters

### DIFF
--- a/matplotlib2tikz/axes.py
+++ b/matplotlib2tikz/axes.py
@@ -58,28 +58,39 @@ class Axes(object):
 
         # get plot title
         title = obj.get_title()
-        if title:
+        if title and 'title' not in data['discard axis options']:
             self.axis_options.append('title={' + title + '}')
 
         # get axes titles
         xlabel = obj.get_xlabel()
-        if xlabel:
+        if xlabel and 'xlabel' not in data['discard axis options']:
             self.axis_options.append('xlabel={' + xlabel + '}')
         ylabel = obj.get_ylabel()
-        if ylabel:
+        if ylabel and 'ylabel' not in data['discard axis options']:
             self.axis_options.append('ylabel={' + ylabel + '}')
 
         # Axes limits.
         # Sort the limits so make sure that the smaller of the two is actually
         # *min.
-        xlim = sorted(list(obj.get_xlim()))
-        self.axis_options.append(
-                'xmin=%.15g' % xlim[0] + ', xmax=%.15g' % xlim[1]
-                )
-        ylim = sorted(list(obj.get_ylim()))
-        self.axis_options.append(
-                'ymin=%.15g' % ylim[0] + ', ymax=%.15g' % ylim[1]
-                )
+        if 'xmin' not in data['discard axis options'] and 'xmax' not in data['discard axis options']:
+            xlim = sorted(list(obj.get_xlim()))
+            if 'xmin' not in data['discard axis options']:
+                app = 'xmin=%.15g' % xlim[0]
+            else:
+                app = ''
+            if 'xmax' not in data['discard axis options']:
+                app = app + ', xmax=%.15g' % xlim[1]
+            self.axis_options.append(app)
+
+        if 'ymin' not in data['discard axis options'] and 'ymax' not in data['discard axis options']:
+            ylim = sorted(list(obj.get_ylim()))
+            if 'ymin' not in data['discard axis options']:
+                app = 'ymin=%.15g' % ylim[0]
+            else:
+                app = ''
+            if 'ymax' not in data['discard axis options']:
+                app = app + ', ymax=%.15g' % ylim[1]
+            self.axis_options.append(app)
 
         # axes scaling
         if obj.get_xscale() == 'log':
@@ -151,12 +162,15 @@ class Axes(object):
             self.axis_options.append('axis y line=right')
 
         # get ticks
-        self.axis_options.extend(
-            _get_ticks(data, 'x', obj.get_xticks(), obj.get_xticklabels())
-            )
-        self.axis_options.extend(
-            _get_ticks(data, 'y', obj.get_yticks(), obj.get_yticklabels())
-            )
+        if 'x ticklabels' not in data['discard axis options']:
+            self.axis_options.extend(
+                _get_ticks(data, 'x', obj.get_xticks(), obj.get_xticklabels())
+                )
+
+        if 'y ticklabels' not in data['discard axis options']:
+            self.axis_options.extend(
+                _get_ticks(data, 'y', obj.get_yticks(), obj.get_yticklabels())
+                )
         self.axis_options.extend(
             _get_ticks(data, 'minor x', obj.get_xticks('minor'),
                        obj.get_xticklabels('minor'))
@@ -187,7 +201,7 @@ class Axes(object):
                 # y_tick_dirs must be present
                 direction = y_tick_dirs[0]
 
-            if direction:
+            if direction and 'tick align' not in data['discard axis options']:
                 if direction == 'in':
                     # 'tick align=inside' is the PGFPlots default
                     pass
@@ -223,29 +237,29 @@ class Axes(object):
         # Coordinate of the lines are entirely meaningless, but styles
         # (colors,...) are respected.
         # pylint: disable=protected-access
-        if obj.xaxis._gridOnMajor:
+        if obj.xaxis._gridOnMajor and 'xmajorgrids' not in data['discard axis options']:
             self.axis_options.append('xmajorgrids')
-        if obj.xaxis._gridOnMinor:
+        if obj.xaxis._gridOnMinor and 'xminorgrids' not in data['discard axis options']:
             self.axis_options.append('xminorgrids')
 
         xlines = obj.get_xgridlines()
         if xlines:
             xgridcolor = xlines[0].get_color()
             data, col, _ = color.mpl_color2xcolor(data, xgridcolor)
-            if col != 'black':
+            if col != 'black' and 'x grid style' not in data['discard axis options']:
                 self.axis_options.append('x grid style={%s}' % col)
 
         # pylint: disable=protected-access
-        if obj.yaxis._gridOnMajor:
+        if obj.yaxis._gridOnMajor and 'ymajorgrids' not in data['discard axis options']:
             self.axis_options.append('ymajorgrids')
-        if obj.yaxis._gridOnMinor:
+        if obj.yaxis._gridOnMinor and 'yminorgrids' not in data['discard axis options']:
             self.axis_options.append('yminorgrids')
 
         ylines = obj.get_ygridlines()
         if ylines:
             ygridcolor = ylines[0].get_color()
             data, col, _ = color.mpl_color2xcolor(data, ygridcolor)
-            if col != 'black':
+            if col != 'black' and 'y grid style' not in data['discard axis options']:
                 self.axis_options.append('y grid style={%s}' % col)
 
         # axis line styles

--- a/matplotlib2tikz/axes.py
+++ b/matplotlib2tikz/axes.py
@@ -162,12 +162,12 @@ class Axes(object):
             self.axis_options.append('axis y line=right')
 
         # get ticks
-        if 'x ticklabels' not in data['discard axis options']:
+        if 'xticklabels' not in data['discard axis options']:
             self.axis_options.extend(
                 _get_ticks(data, 'x', obj.get_xticks(), obj.get_xticklabels())
                 )
 
-        if 'y ticklabels' not in data['discard axis options']:
+        if 'yticklabels' not in data['discard axis options']:
             self.axis_options.extend(
                 _get_ticks(data, 'y', obj.get_yticks(), obj.get_yticklabels())
                 )
@@ -237,9 +237,11 @@ class Axes(object):
         # Coordinate of the lines are entirely meaningless, but styles
         # (colors,...) are respected.
         # pylint: disable=protected-access
-        if obj.xaxis._gridOnMajor and 'xmajorgrids' not in data['discard axis options']:
+        if obj.xaxis._gridOnMajor \
+                and 'xmajorgrids' not in data['discard axis options']:
             self.axis_options.append('xmajorgrids')
-        if obj.xaxis._gridOnMinor and 'xminorgrids' not in data['discard axis options']:
+        if obj.xaxis._gridOnMinor \
+                and 'xminorgrids' not in data['discard axis options']:
             self.axis_options.append('xminorgrids')
 
         xlines = obj.get_xgridlines()

--- a/matplotlib2tikz/axes.py
+++ b/matplotlib2tikz/axes.py
@@ -72,7 +72,8 @@ class Axes(object):
         # Axes limits.
         # Sort the limits so make sure that the smaller of the two is actually
         # *min.
-        if 'xmin' not in data['discard axis options'] and 'xmax' not in data['discard axis options']:
+        if 'xmin' not in data['discard axis options'] \
+            and 'xmax' not in data['discard axis options']:
             xlim = sorted(list(obj.get_xlim()))
             if 'xmin' not in data['discard axis options']:
                 app = 'xmin=%.15g' % xlim[0]
@@ -82,7 +83,8 @@ class Axes(object):
                 app = app + ', xmax=%.15g' % xlim[1]
             self.axis_options.append(app)
 
-        if 'ymin' not in data['discard axis options'] and 'ymax' not in data['discard axis options']:
+        if 'ymin' not in data['discard axis options'] \
+            and 'ymax' not in data['discard axis options']:
             ylim = sorted(list(obj.get_ylim()))
             if 'ymin' not in data['discard axis options']:
                 app = 'ymin=%.15g' % ylim[0]

--- a/matplotlib2tikz/legend.py
+++ b/matplotlib2tikz/legend.py
@@ -189,28 +189,29 @@ def draw_legend(data, obj):
             alignment = None
             break
 
-    if alignment:
+    if alignment and 'legend cell align' not in data['discard axis options']:
         data['extra axis options'].add(
             'legend cell align={{{}}}'.format(alignment)
             )
 
-    if obj._ncol != 1:
+    if obj._ncol != 1 and 'legend columns' not in data['discard axis options']:
         data['extra axis options'].add(
             'legend columns={}'.format(obj._ncol)
             )
 
     # Set color of lines in legend
-    for handle in obj.legendHandles:
-        try:
-            data, legend_color, _ = mycol.mpl_color2xcolor(data,
-                                                            handle.get_color())
-            data['legend colors'].append('\\addlegendimage{no markers, %s}\n'
-                                        % legend_color)
-        except AttributeError:
-            pass
+    if not data['addplot_inherit_global_parameters']:
+        for handle in obj.legendHandles:
+            try:
+                data, legend_color, _ = mycol.mpl_color2xcolor(data,
+                                                                handle.get_color())
+                data['legend colors'].append('\\addlegendimage{no markers, %s}\n'
+                                            % legend_color)
+            except AttributeError:
+                pass
 
     # Write styles to data
-    if legend_style:
+    if legend_style and 'legend style' not in data['discard axis options']:
         style = 'legend style={%s}' % ', '.join(legend_style)
         data['extra axis options'].add(style)
 

--- a/matplotlib2tikz/line2d.py
+++ b/matplotlib2tikz/line2d.py
@@ -114,10 +114,13 @@ def draw_line2d(data, obj):
         addplot_options.append("forget plot")
 
     # process options
-    content.append('\\addplot ')
-    if addplot_options:
-        options = ', '.join(addplot_options)
-        content.append('[' + options + ']\n')
+    if data['addplot_inherit_global_parameters']:
+        content.append('\\addplot +[]\n')
+    else:
+        content.append('\\addplot ')
+        if addplot_options:
+            options = ', '.join(addplot_options)
+            content.append('[' + options + ']\n')
 
     content.append('table {%\n')
 

--- a/matplotlib2tikz/save.py
+++ b/matplotlib2tikz/save.py
@@ -233,10 +233,11 @@ def _get_color_definitions(data):
     '''Returns the list of custom color definitions for the TikZ file.
     '''
     definitions = []
-    for name, rgb in data['custom colors'].items():
-        definitions.append('\\definecolor{%s}{rgb}{%.15g,%.15g,%.15g}'
-                           % (name, rgb[0], rgb[1], rgb[2])
-                           )
+    if 'definecolor' not in data['discard axis options']:
+        for name, rgb in data['custom colors'].items():
+            definitions.append('\\definecolor{%s}{rgb}{%.15g,%.15g,%.15g}'
+                               % (name, rgb[0], rgb[1], rgb[2])
+                               )
     return definitions
 
 

--- a/matplotlib2tikz/save.py
+++ b/matplotlib2tikz/save.py
@@ -30,7 +30,9 @@ def get_tikz_code(
         wrap=True,
         axis_environment=True,
         extra_axis_parameters=None,
+        discard_axis_parameters=None,
         extra_tikzpicture_parameters=None,
+        addplot_inherit_global_parameters=False,
         dpi=None,
         show_info=True
         ):
@@ -95,11 +97,21 @@ def get_tikz_code(
                                     to pgfplots. Default is ``None``.
     :type extra_axis_parameters: a set of strings for the pfgplots axes.
 
+    :param discard_axis_parameters: Axis options to be skipped during save
+                                    (as a set) to pgfplots. Default is ``None``.
+    :type discard_axis_parameters: a set of strings in form of pgfplots options.
+
     :param extra_tikzpicture_parameters: Extra tikzpicture options to be passed
                                         (as a set) to pgfplots.
 
     :type extra_tikzpicture_parameters: a set of strings for the pfgplots
                                         tikzpicture.
+
+    :param addplot_inherit_global_parameters: Whether to use ``\\addplot + []``
+                                                and skipped the extra options in []
+                                                or ``\\addplot [extra options]``.
+                                                Default is ``False``.
+    :type addplot_inherit_global_parameters: bool
 
     :param dpi: The resolution in dots per inch of the rendered image in case
                 of QuadMesh plots. If ``None`` it will default to the value
@@ -135,6 +147,7 @@ def get_tikz_code(
     data['extra tikzpicture parameters'] = extra_tikzpicture_parameters
     data['axis environment'] = axis_environment
     data['show_info'] = show_info
+    data['addplot_inherit_global_parameters'] = addplot_inherit_global_parameters
     # rectangle_legends is used to keep track of which rectangles have already
     # had \addlegendimage added. There should be only one \addlegenimage per
     # bar chart data series.
@@ -143,6 +156,11 @@ def get_tikz_code(
         data['extra axis options [base]'] = extra_axis_parameters.copy()
     else:
         data['extra axis options [base]'] = set()
+
+    if discard_axis_parameters:
+        data['discard axis options'] = discard_axis_parameters.copy()
+    else:
+        data['discard axis options'] = set()
 
     if dpi:
         data['dpi'] = dpi
@@ -281,6 +299,7 @@ def _recurse(data, obj):
             if not ax.is_colorbar:
                 # Run through the child objects, gather the content.
                 data, children_content = _recurse(data, child)
+
                 # add extra axis options from children
                 if data['extra axis options']:
                     ax.axis_options.extend(data['extra axis options'])


### PR DESCRIPTION
I added some options to the `save` function that allows to exclude some parameters from exporting.
I use this option mainly, because there are some settings which I set globally in my latex documents using `\pgfplotsset{}`.

@nschloe Are you generally interested in merging such options (maybe after polishing/reworking this code)? If so, are there some options I'm missing?