### PR TITLE
catching error during messy RGBA colour handling

### DIFF
--- a/matplotlib2tikz/legend.py
+++ b/matplotlib2tikz/legend.py
@@ -211,7 +211,7 @@ def draw_legend(data, obj):
                     data, handle.get_color())
             except ValueError:
                 data, legend_color, _ = mycol.mpl_color2xcolor(
-                    data, numpy.squeeze(numpy.array(handle.get_color())))
+                    data, numpy.squeeze(handle.get_color()))
             data['legend colors'].append('\\addlegendimage{no markers, %s}\n'
                                         % legend_color)
         except AttributeError:

--- a/matplotlib2tikz/legend.py
+++ b/matplotlib2tikz/legend.py
@@ -202,6 +202,10 @@ def draw_legend(data, obj):
     # Set color of lines in legend
     for handle in obj.legendHandles:
         try:
+            # when using matplotlib colours like "darkred" or "darkorange",
+            # `handle.get_color` will create nested RGBA codes
+            # e.g. `[[ 0.54509804, 0., 0., 1.]]` which casuse mpl to throw an error.
+            # catch this error, `numpy.squeeze` the colour code and try again
             try:
                 data, legend_color, _ = mycol.mpl_color2xcolor(
                     data, handle.get_color())

--- a/matplotlib2tikz/legend.py
+++ b/matplotlib2tikz/legend.py
@@ -202,8 +202,12 @@ def draw_legend(data, obj):
     # Set color of lines in legend
     for handle in obj.legendHandles:
         try:
-            data, legend_color, _ = mycol.mpl_color2xcolor(data,
-                                                            handle.get_color())
+            try:
+                data, legend_color, _ = mycol.mpl_color2xcolor(
+                    data, handle.get_color())
+            except ValueError:
+                data, legend_color, _ = mycol.mpl_color2xcolor(
+                    data, numpy.squeeze(numpy.array(handle.get_color())))
             data['legend colors'].append('\\addlegendimage{no markers, %s}\n'
                                         % legend_color)
         except AttributeError:


### PR DESCRIPTION
When using matplotlib colours like "darkorange" or "darkred"

https://github.com/nschloe/matplotlib2tikz/blob/66da89dcd5c6b3eff14602ae28e14bc10075ff00/matplotlib2tikz/legend.py#L206

creates nested RGBA codes like
```
[[ 0.54509804  0.          0.          1.        ]]
[[ 1.          0.54901961  0.          1.        ]]
```
and matplotlib will throw an error.

With this PR, the error gets caught and the function call repeated with a `numpy.squeeze` applied to the colour.