### PR TITLE
Add option to externalize tabular data

### DIFF
--- a/matplotlib2tikz/files.py
+++ b/matplotlib2tikz/files.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+#
+import os
+
+def new_filename(data, file_kind, ext):
+    '''Returns an available filename.
+
+    :param file_kind: Name under which numbering is recorded, such as 'img' or
+                      'table'.
+    :type file_kind: str
+
+    :param ext: Filename extension.
+    :type ext: str
+
+    :returns: (filename, rel_filepath) where filename is a path in the
+              filesystem and rel_filepath is the path to be used in the tex
+              code.
+    '''
+
+    nb_key = file_kind + 'number'
+    if nb_key not in data.keys():
+        data[nb_key] = 0
+
+    # Make sure not to overwrite anything.
+    file_exists = True
+    while file_exists:
+        data[nb_key] = data[nb_key] + 1
+        name = data['base name'] + '-%03d%s' % (data[nb_key], ext)
+        filename = os.path.join(data['output dir'], name)
+        file_exists = os.path.isfile(filename)
+
+    if data['rel data path']:
+        rel_filepath = os.path.join(data['rel data path'], name)
+    else:
+        rel_filepath = name
+
+    return filename, rel_filepath

--- a/matplotlib2tikz/image.py
+++ b/matplotlib2tikz/image.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 #
-import os
-
 import matplotlib as mpl
 import numpy
 import PIL
+
+from . import files
 
 
 def draw_image(data, obj):
@@ -12,18 +12,7 @@ def draw_image(data, obj):
     '''
     content = []
 
-    if 'img number' not in data.keys():
-        data['img number'] = 0
-
-    # Make sure not to overwrite anything.
-    file_exists = True
-    while file_exists:
-        data['img number'] = data['img number'] + 1
-        filename = os.path.join(
-            data['output dir'],
-            data['base name'] + str(data['img number']) + '.png'
-        )
-        file_exists = os.path.isfile(filename)
+    filename, rel_filepath = files.new_filename(data, 'img', '.png')
 
     # store the image as in a file
     img_array = obj.get_array()
@@ -60,10 +49,6 @@ def draw_image(data, obj):
     # the format specification will only accept tuples
     if not isinstance(extent, tuple):
         extent = tuple(extent)
-
-    rel_filepath = os.path.basename(filename)
-    if data['rel data path']:
-        rel_filepath = os.path.join(data['rel data path'], rel_filepath)
 
     # Explicitly use \pgfimage as includegrapics command, as the default
     # \includegraphics fails unexpectedly in some cases

--- a/matplotlib2tikz/line2d.py
+++ b/matplotlib2tikz/line2d.py
@@ -6,6 +6,7 @@ import six
 
 from . import color as mycol
 from . import path as mypath
+from . import files
 
 def get_legend_label_(line):
     '''Check if line is in legend
@@ -144,6 +145,7 @@ def draw_line2d(data, obj):
     except AttributeError:
         has_mask = 0
 
+    plot_table = []
     if has_mask:
         # matplotlib jumps at masked images, while PGFPlots by default
         # interpolates. Hence, if we have a masked plot, make sure that
@@ -151,12 +153,21 @@ def draw_line2d(data, obj):
         data['extra axis options'].add('unbounded coords=jump')
         for (x, y, is_masked) in zip(xdata, ydata, ydata.mask):
             if is_masked:
-                content.append('%.15g nan\n' % x)
+                plot_table.append('%.15g\tnan\n' % x)
             else:
-                content.append('%.15g %.15g\n' % (x, y))
+                plot_table.append('%.15g\t%.15g\n' % (x, y))
     else:
         for (x, y) in zip(xdata, ydata):
-            content.append('%.15g %.15g\n' % (x, y))
+            plot_table.append('%.15g\t%.15g\n' % (x, y))
+    if data["externalize tables"]:
+        filename, rel_filepath = files.new_filename(data, 'table', '.tsv')
+        with open(filename, 'w') as f:
+            # No encoding handling required: plot_table is only ASCII
+            f.write(''.join(plot_table))
+        content.append(rel_filepath)
+    else:
+        content.extend(plot_table)
+
     content.append('};\n')
 
     return data, content

--- a/matplotlib2tikz/quadmesh.py
+++ b/matplotlib2tikz/quadmesh.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 #
-import os
-
 from PIL import Image
+
+from . import files
 
 
 def draw_quadmesh(data, obj):
@@ -12,14 +12,7 @@ def draw_quadmesh(data, obj):
     content = []
 
     # Generate file name for current object
-    if 'img number' not in data.keys():
-        data['img number'] = 0
-
-    filename = os.path.join(
-            data['output dir'],
-            '%s_img%03d.png' % (data['base name'], data['img number'])
-            )
-    data['img number'] = data['img number'] + 1
+    filename, rel_filepath = files.new_filename(data, 'img', '.png')
 
     # Get the dpi for rendering and store the original dpi of the figure
     dpi = data['dpi']
@@ -60,10 +53,6 @@ def draw_quadmesh(data, obj):
 
     # write the corresponding information to the TikZ file
     extent = obj.axes.get_xlim() + obj.axes.get_ylim()
-
-    rel_filepath = os.path.basename(filename)
-    if data['rel data path']:
-        rel_filepath = os.path.join(data['rel data path'], rel_filepath)
 
     # Explicitly use \pgfimage as includegrapics command, as the default
     # \includegraphics fails unexpectedly in some cases

--- a/matplotlib2tikz/save.py
+++ b/matplotlib2tikz/save.py
@@ -26,6 +26,7 @@ def get_tikz_code(
         figureheight=None,
         textsize=10.0,
         tex_relative_path_to_data=None,
+        externalize_tables=False,
         strict=False,
         wrap=True,
         axis_environment=True,
@@ -72,6 +73,10 @@ def get_tikz_code(
                                       relative path from the LaTeX file to the
                                       data.
     :type tex_relative_path_to_data: str
+
+    :param externalize_tables: Whether or not to externalize plot data tables
+                               into tsv files.
+    :type externalize_tables: bool
 
     :param strict: Whether or not to strictly stick to matplotlib's appearance.
                    This influences, for example, whether tick marks are set
@@ -124,6 +129,7 @@ def get_tikz_code(
     data['fwidth'] = figurewidth
     data['fheight'] = figureheight
     data['rel data path'] = tex_relative_path_to_data
+    data['externalize tables'] = externalize_tables
     data['output dir'] = os.path.dirname(filepath)
     data['base name'] = os.path.splitext(os.path.basename(filepath))[0]
     data['strict'] = strict

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -19,13 +19,16 @@ import matplotlib2tikz
 
 
 class Phash(object):
-    def __init__(self, fig):
+    def __init__(self, fig, save_kwargs=None):
+        if save_kwargs is None:
+            save_kwargs = dict()
         # convert to tikz file
         _, tmp_base = tempfile.mkstemp()
         tikz_file = tmp_base + '_tikz.tex'
         matplotlib2tikz.save(
             tikz_file,
-            figurewidth='7.5cm'
+            figurewidth='7.5cm',
+            **save_kwargs
             )
 
         # test other height specs
@@ -34,6 +37,7 @@ class Phash(object):
             figureheight='7.5cm',
             show_info=True,
             strict=True,
+            **save_kwargs
             )
 
         # save reference figure

--- a/test/test_externalize_tables.py
+++ b/test/test_externalize_tables.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+#
+import helpers
+
+
+def plot():
+    from matplotlib import pyplot as plt
+    import numpy as np
+
+    fig = plt.figure()
+    with plt.style.context(('ggplot')):
+        t = np.arange(0.0, 2.0, 0.1)
+        s = np.sin(2*np.pi*t)
+        s2 = np.cos(2*np.pi*t)
+        A = plt.cm.jet(np.linspace(0, 1, 10))
+        plt.plot(t, s, 'o-', lw=1.5, color=A[5])
+        plt.plot(t, s2, 'o-', lw=3, alpha=0.3)
+        plt.xlabel('time(s)')
+        # plt.xlabel('time(s) _ % $ \\')
+        plt.ylabel('Voltage (mV)')
+        plt.title('Simple plot $\\frac{\\alpha}{2}$')
+        plt.grid(True)
+    return fig
+
+
+def test():
+    phash = helpers.Phash(
+            plot(),
+            save_kwargs={
+                'externalize_tables': True,
+                },
+            )
+    assert phash.phash == '1f36e5ce21c1e5c1', phash.get_details()
+
+
+if __name__ == '__main__':
+    helpers.compare_with_latex(plot())


### PR DESCRIPTION
The externalized data is saved in .tsv files (uses built-in support of pgfplots).

This makes it easier to edit the style of the plot since the generated
LaTeX is smaller.

This is a feature I often use and I thought it might be worth it to upstream it.
