### PR TITLE
Add option to overwrite existing external files

### DIFF
--- a/matplotlib2tikz/files.py
+++ b/matplotlib2tikz/files.py
@@ -2,6 +2,10 @@
 #
 import os
 
+def _gen_filename(data, nb_key, ext):
+    name = data['base name'] + '-%03d%s' % (data[nb_key], ext)
+    return os.path.join(data['output dir'], name), name
+
 def new_filename(data, file_kind, ext):
     '''Returns an available filename.
 
@@ -19,15 +23,18 @@ def new_filename(data, file_kind, ext):
 
     nb_key = file_kind + 'number'
     if nb_key not in data.keys():
-        data[nb_key] = 0
+        data[nb_key] = -1
 
-    # Make sure not to overwrite anything.
-    file_exists = True
-    while file_exists:
+    if not data["override externals"]:
+        # Make sure not to overwrite anything.
+        file_exists = True
+        while file_exists:
+            data[nb_key] = data[nb_key] + 1
+            filename, name = _gen_filename(data, nb_key, ext)
+            file_exists = os.path.isfile(filename)
+    else:
         data[nb_key] = data[nb_key] + 1
-        name = data['base name'] + '-%03d%s' % (data[nb_key], ext)
-        filename = os.path.join(data['output dir'], name)
-        file_exists = os.path.isfile(filename)
+        filename, name = _gen_filename(data, nb_key, ext)
 
     if data['rel data path']:
         rel_filepath = os.path.join(data['rel data path'], name)

--- a/matplotlib2tikz/save.py
+++ b/matplotlib2tikz/save.py
@@ -27,6 +27,7 @@ def get_tikz_code(
         textsize=10.0,
         tex_relative_path_to_data=None,
         externalize_tables=False,
+        override_externals=False,
         strict=False,
         wrap=True,
         axis_environment=True,
@@ -77,6 +78,12 @@ def get_tikz_code(
     :param externalize_tables: Whether or not to externalize plot data tables
                                into tsv files.
     :type externalize_tables: bool
+
+    :param override_externals: Whether or not to override existing external
+                               files (such as tsv or images) with conflicting
+                               names (the alternative is to choose other
+                               names).
+    :type override_externals: bool
 
     :param strict: Whether or not to strictly stick to matplotlib's appearance.
                    This influences, for example, whether tick marks are set
@@ -130,6 +137,7 @@ def get_tikz_code(
     data['fheight'] = figureheight
     data['rel data path'] = tex_relative_path_to_data
     data['externalize tables'] = externalize_tables
+    data['override externals'] = override_externals
     data['output dir'] = os.path.dirname(filepath)
     data['base name'] = os.path.splitext(os.path.basename(filepath))[0]
     data['strict'] = strict

--- a/test/test_externalize_tables.py
+++ b/test/test_externalize_tables.py
@@ -32,6 +32,15 @@ def test():
             )
     assert phash.phash == '1f36e5ce21c1e5c1', phash.get_details()
 
+    phash = helpers.Phash(
+            plot(),
+            save_kwargs={
+                'externalize_tables': True,
+                'override_externals': True,
+                },
+            )
+    assert phash.phash == '1f36e5ce21c1e5c1', phash.get_details()
+
 
 if __name__ == '__main__':
     helpers.compare_with_latex(plot())


### PR DESCRIPTION
This is useful when running multiple times the same script, it avoids
adding indefinitely new files.

Mainly (but not only) useful as a follow-up to #232