### PR TITLE
Make output deterministic

### DIFF
--- a/matplotlib2tikz/axes.py
+++ b/matplotlib2tikz/axes.py
@@ -138,6 +138,8 @@ class Axes(object):
     def get_begin_code(self):
         content = self.content
         if self.axis_options:
+            # Put axis_options in a deterministic order to avoid diff churn.
+            self.axis_options.sort()
             content.append("[\n" + ",\n".join(self.axis_options) + "\n]\n")
         return content
 

--- a/matplotlib2tikz/save.py
+++ b/matplotlib2tikz/save.py
@@ -7,6 +7,7 @@ import os
 import warnings
 
 import matplotlib as mpl
+import matplotlib.pyplot as plt
 import six
 
 from . import axes
@@ -133,7 +134,7 @@ def get_tikz_code(
     """
     # not as default value because gcf() would be evaluated at import time
     if figure == "gcf":
-        figure = mpl.pyplot.gcf()
+        figure = plt.gcf()
     data = {}
     data["fwidth"] = figurewidth
     data["fheight"] = figureheight

--- a/test/test_deterministic_output.py
+++ b/test/test_deterministic_output.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+#
+# assert repeated exports of the same plot produce the same output file
+
+import sys
+import tempfile
+import subprocess
+
+# We create the tikz files in separate subprocesses, as when producing those in
+# the same process, the order of axis parameters is deterministic.
+plot_code = """
+import sys
+import numpy as np
+from matplotlib import pyplot as plt
+import matplotlib2tikz
+
+t = np.arange(0.0, 2.0, 0.1)
+s = np.sin(2 * np.pi * t)
+plt.plot(t, s, label="a")
+plt.legend()
+matplotlib2tikz.save(sys.argv[1])
+"""
+
+
+def test():
+    _, tmp_base = tempfile.mkstemp()
+    # trade-off between test duration and probability of false negative
+    n_tests = 4
+    tikzs = []
+    for i in range(n_tests):
+        tikz_file = tmp_base + "_tikz.tex"
+        try:
+            mpltt_out = subprocess.check_output(
+                [sys.executable, "-", tikz_file],
+                input=plot_code.encode(),
+                stderr=subprocess.STDOUT,
+            )
+            sp = subprocess.Popen(
+                ["python", "-", tikz_file],
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+            )
+            (mpltt_out, _) = sp.communicate(plot_code.encode())
+        except subprocess.CalledProcessError as e:
+            print("Command output:")
+            print("=" * 70)
+            print(e.output)
+            print("=" * 70)
+            raise
+        with open(tikz_file) as f:
+            tikzs.append(f.read())
+    for t in tikzs[1:]:
+        assert t == tikzs[0]
+
+
+if __name__ == "__main__":
+    test()


### PR DESCRIPTION
Order of parameters of tikz axis changed between calls, which caused
unnecessary diff churn when using VCS.
This makes the order deterministic.