### PR TITLE
use \\ row separator for more stable inline tables

### DIFF
--- a/matplotlib2tikz/line2d.py
+++ b/matplotlib2tikz/line2d.py
@@ -378,10 +378,10 @@ def _marker(
 def _table(obj, content, data):
     if data["externalize tables"]:
         content.append("table {%\n")
-        row_sep = ''
+        row_sep = ""
     else:
         content.append("table [row sep=\\\\]{%\n")
-        row_sep = '\\\\'
+        row_sep = "\\\\"
 
     # nschloe, Oct 2, 2015:
     #   The transform call yields warnings and it is unclear why. Perhaps

--- a/matplotlib2tikz/line2d.py
+++ b/matplotlib2tikz/line2d.py
@@ -376,7 +376,12 @@ def _marker(
 
 
 def _table(obj, content, data):
-    content.append("table {%\n")
+    if data["externalize tables"]:
+        content.append("table {%\n")
+        row_sep = ''
+    else:
+        content.append("table [row sep=\\\\]{%\n")
+        row_sep = '\\\\'
 
     # nschloe, Oct 2, 2015:
     #   The transform call yields warnings and it is unclear why. Perhaps
@@ -409,12 +414,12 @@ def _table(obj, content, data):
         data["extra axis options"].add("unbounded coords=jump")
         for (x, y, is_masked) in zip(xdata, ydata, ydata.mask):
             if is_masked:
-                plot_table.append("%.15g\tnan\n" % x)
+                plot_table.append("%.15g\tnan %s\n" % (x, row_sep))
             else:
-                plot_table.append("%.15g\t%.15g\n" % (x, y))
+                plot_table.append("%.15g\t%.15g %s\n" % (x, y, row_sep))
     else:
         for (x, y) in zip(xdata, ydata):
-            plot_table.append("%.15g\t%.15g\n" % (x, y))
+            plot_table.append("%.15g\t%.15g %s\n" % (x, y, row_sep))
 
     if data["externalize tables"]:
         filename, rel_filepath = files.new_filename(data, "table", ".tsv")

--- a/matplotlib2tikz/path.py
+++ b/matplotlib2tikz/path.py
@@ -100,7 +100,7 @@ def draw_pathcollection(data, obj):
     dd = obj.get_offsets()
 
     draw_options = ["only marks"]
-    table_options = []
+    table_options = ["row sep=\\\\"]
 
     if obj.get_array() is not None:
         draw_options.append("scatter")
@@ -164,8 +164,8 @@ def draw_pathcollection(data, obj):
         to = " [{}]".format(", ".join(table_options)) if table_options else ""
         content.append("table{}{{%\n".format(to))
 
-        content.append((" ".join(labels)).strip() + "\n")
-        fmt = (" ".join(dd.shape[1] * ["%+.15e"])) + "\n"
+        content.append((" ".join(labels)).strip() + "\\\\ \n")
+        fmt = (" ".join(dd.shape[1] * ["%+.15e"])) + "\\\\ \n"
         for d in dd:
             content.append(fmt % tuple(d))
         content.append("};\n")


### PR DESCRIPTION
The current format of inline tables (using \n as a row separator) breaks in certain latex usage scenarios. This PR changes the format to use \\ to separate rows.